### PR TITLE
fix image breaking

### DIFF
--- a/events/2023-07-11-ml-for-programming.md
+++ b/events/2023-07-11-ml-for-programming.md
@@ -5,7 +5,7 @@ title: ML for Programming
 
 # 프로그래밍을 위한 기계학습 @ KAIST
 
-<img src=../images/ml4pl_23summer.jpg alt="group image" width=90%>
+<div> <img src=../images/ml4pl_23summer.jpg alt="group image" width=90%> </div>
 
 ### 개요
 


### PR DESCRIPTION
이미지 안 나오는 버그를 고쳤습니다.
markdown이 html로 convert될 때, markdown에 있는 `<img>`가 깨지는군요. 

로컬에서 github.io와 동일한 세팅으로 markdown-to-html coverter를 돌리기 어려워
github.io에 잘 나올지 테스트가 힘드네요..
이제는 아마 잘 될 겁니다.

- by wrapping around with div
- reference: https://github.com/mkdocs/mkdocs/discussions/2423